### PR TITLE
Update httemplate/elements/selectlayers.html

### DIFF
--- a/httemplate/elements/selectlayers.html
+++ b/httemplate/elements/selectlayers.html
@@ -146,7 +146,7 @@ Example:
 
       <DIV ID="<% $key %>d<% $layer %>"
            STYLE="<% $selected_layer eq $layer
-                       ? 'display: ""  ; z-index: 1'
+                       ? 'display: block; z-index: 1'
                        : 'display: none; z-index: 0'
                   %>"
       >


### PR DESCRIPTION
Changed '""' to 'block'.

This code was generating "<DIV ID="paybydCARD" STYLE="display: ""; z-index: 1">

This might cause unexpected behavior in some browsers and the display property should be a block element (when displayed).
