### PR TITLE
Update httemplate/elements/searchbar-cust_svc.html

### DIFF
--- a/httemplate/elements/searchbar-cust_svc.html
+++ b/httemplate/elements/searchbar-cust_svc.html
@@ -5,7 +5,7 @@
     <A NOTYET="<%$fsurl%>search/svc_Smarter.html" STYLE="color: #cccccc; font-size:11px"><% mt('Advanced') |h %></A>
     <INPUT TYPE="submit" VALUE="<% mt('Search services') |h %>" CLASS="fsblackbutton" onMouseOver="this.className='fsblackbuttonselected'; return true;" onMouseOut="this.className='fsblackbutton'; return true;" STYLE="font-size:11px">
   </FORM>
-  <% $menu_position eq 'left' ? '<BR>' : '' %>
+  <% $menu_position eq 'left' ? '<BR>' : '' |n %>
 
 % }
 


### PR DESCRIPTION
Fixed issue where html break tags are being escaped erroneously causing break tags to be displayed in the navigation menu.

This issue can be reproduced by doing the following:
1. Change the Freeside user's preference to display the menu on the left.
2. Click "Ticketing Main"
