### PR TITLE
Update httemplate/elements/searchbar-prospect.html

### DIFF
--- a/httemplate/elements/searchbar-prospect.html
+++ b/httemplate/elements/searchbar-prospect.html
@@ -5,7 +5,7 @@
     <A HREF="<%$fsurl%>search/report_prospect_main.html" CLASS="fslink" STYLE="font-size: 11px">Adv</A>
     <INPUT TYPE="submit" VALUE="Search prospects" CLASS="fsblackbutton" onMouseOver="this.className='fsblackbuttonselected'; return true;" onMouseOut="this.className='fsblackbutton'; return true;" STYLE="font-size:11px;padding-left:1px;padding-right:1px">
   </FORM>
-  <% $menu_position eq 'left' ? '<BR>' : '' %>
+  <% $menu_position eq 'left' ? '<BR>' : '' |n %>
 
 % }
 


### PR DESCRIPTION
Fixed issue where html break tags are being escaped erroneously causing break tags to be displayed in the navigation menu.

This issue can be reproduced by doing the following:
1. Change the Freeside user's preference to display the menu on the left.
2. Click "Ticketing Main"
