### PR TITLE
Update httemplate/elements/searchbar-cust_bill.html

### DIFF
--- a/httemplate/elements/searchbar-cust_bill.html
+++ b/httemplate/elements/searchbar-cust_bill.html
@@ -8,7 +8,7 @@
     <BR>
     <INPUT TYPE="submit" VALUE="<% mt('Search invoices') |h %>" CLASS="fsblackbutton" onMouseOver="this.className='fsblackbuttonselected'; return true;" onMouseOut="this.className='fsblackbutton'; return true;" STYLE="font-size:11px;padding-left:1px;padding-right:1px;margin-top:3px">
   </FORM>
-  <% $menu_position eq 'left' ? '<BR><BR>' : '' %>
+  <% $menu_position eq 'left' ? '<BR><BR>' : '' |n %>
 
 % } 
 


### PR DESCRIPTION
Fixed issue where html break tags are being escaped erroneously causing break tags to be displayed in the navigation menu.

This issue can be reproduced by doing the following:
1. Change the Freeside user's preference to display the menu on the left.
2. Click "Ticketing Main"
