### PR TITLE
New secrets format based on Config::General for named connections.

### DIFF
--- a/FS/FS/UID.pm
+++ b/FS/FS/UID.pm
@@ -12,6 +12,7 @@ use Carp qw( carp croak cluck confess );
 use DBI;
 use IO::File;
 use FS::CurrentUser;
+use Config::General;
 
 @ISA = qw(Exporter);
 @EXPORT_OK = qw( checkeuid checkruid cgi setcgi adminsuidsetup forksuidsetup
@@ -147,7 +148,7 @@ sub db_setup {
       $use_confcompat = 0;
     }else{
       die "NO CONFIGURATION RECORDS FOUND";
-    }
+    
 
   } else {
     die "NO CONFIGURATION TABLE FOUND" unless $FS::Schema::setup_hack;
@@ -173,13 +174,18 @@ sub callback_setup {
 }
 
 sub myconnect {
-  my $handle = DBI->connect( getsecrets(), { 'AutoCommit'         => 0,
-                                             'ChopBlanks'         => 1,
-                                             'ShowErrorStatement' => 1,
-                                             'pg_enable_utf8'     => 1,
-                                             #'mysql_enable_utf8'  => 1,
-                                           }
-                           )
+  my $options = shift || {};
+  unless (ref $options) {
+      # Handle being passed a username
+      $options = { user => $options };
+  }
+  my $handle = DBI->connect( getsecrets($options), 
+    { 'AutoCommit'         => 0,
+      'ChopBlanks'         => 1,
+      'ShowErrorStatement' => 1,
+      'pg_enable_utf8'     => 1,
+      #'mysql_enable_utf8'  => 1,
+    })
     or die "DBI->connect error: $DBI::errstr\n";
 
   if ( $schema ) {
@@ -314,10 +320,20 @@ the `/usr/local/etc/freeside/secrets' file.
 =cut
 
 sub getsecrets {
+  my $options = shift || { };
 
-  ($datasrc, $db_user, $db_pass, $schema) = 
-    map { /^(.*)$/; $1 } readline(new IO::File "$conf_dir/secrets")
-      or die "Can't get secrets: $conf_dir/secrets: $!\n";
+  $options->{'ServerName'} ||= 'main';
+
+  my $secrets = Config::General->new("$conf_dir/secrets")
+    or die "Can't get secrets: $conf_dir/secrets: $!\n";
+
+  die "Could not find a $options->{'ServerName'} configuration. Is secrets file not in Config::General format?"
+    unless {$secrets->getall}->{'server'}->{$options->{'ServerName'}};
+
+  ($datasrc, $db_user, $db_pass, $schema) = map {
+    {$secrets->getall}->{'server'}->{$options->{'ServerName'}}->{$_}}
+    qw/DSN Username Password Schema/;
+
   undef $driver_name;
 
   ($datasrc, $db_user, $db_pass);

--- a/FS/bin/freeside-upgrade
+++ b/FS/bin/freeside-upgrade
@@ -12,6 +12,7 @@ use FS::Misc::prune qw(prune_applications);
 use FS::Conf;
 use FS::Record qw(qsearch);
 use FS::Upgrade qw(upgrade_schema upgrade_config upgrade upgrade_sqlradius);
+use Config::General;
 
 my $start = time;
 
@@ -27,6 +28,33 @@ $DRY_RUN = $opt_d;
 my $user = shift or die &usage;
 $FS::CurrentUser::upgrade_hack = 1;
 $FS::UID::callback_hack = 1;
+
+# Check for old secrets file format and upgrade, if neccessary
+my $secrets_file = "%%%FREESIDE_CONF%%%/secrets";
+my $conf = Config::General->new($secrets_file);
+
+unless ({$conf->getall}->{'server'}->{'main'}) {
+  warn "secrets file is not in Config::General format";
+  my ($datasrc, $db_user, $db_pass, $schema) = 
+    map { /^(.*)$/; $1 } readline(new IO::File $secrets_file);
+
+  my $new_config = {
+    server => {
+      'main'   => {
+        ServerType  => 'ReadWrite',
+        DSN     => $datasrc,
+        Username  => $db_user,
+        Password  => $db_pass,
+      }
+    }
+  };
+
+  $new_config->{'server'}->{'main'}->{'Schema'} = $schema
+    if $schema;
+
+  $conf->save_file($secrets_file, $new_config);
+}
+
 my $dbh = adminsuidsetup($user);
 $FS::UID::callback_hack = 0;
 


### PR DESCRIPTION
This is a rework of a previous attempt to create readonly database handles. While the previous work provided for backwards compatibility for the current secrets file format, this does not. There is now new code in freeside-upgrade that migrates from the old format to the new Config::General-based format. 
