### PR TITLE
apply amount can be exactly the amount credited

### DIFF
--- a/FS/FS/cust_credit_bill.pm
+++ b/FS/FS/cust_credit_bill.pm
@@ -131,7 +131,7 @@ sub check {
   $self->_date(time) unless $self->_date;
 
   return "Cannot apply more than remaining value of credit"
-    unless $self->amount <= $self->cust_credit->credited;
+    unless $self->amount < $self->cust_credit->credited;
 
   return "Cannot apply more than remaining value of invoice"
     unless $self->amount <= $self->cust_bill->owed;


### PR DESCRIPTION
When calling FS::cust_credit_bill->new() and passing it an amount exactly equal to the amount credited in a credit referenced by crednum, check() was returning with a message: "Cannot apply more than remaining value of credit." It seems we should be able to apply the exact amount.
