### PR TITLE
Add indexes on paynum, and void_paynum. Paynum was causing major

### DIFF
--- a/FS/FS/Schema.pm
+++ b/FS/FS/Schema.pm
@@ -2270,7 +2270,7 @@ sub tables_hashref {
       ],
       'primary_key'  => 'paypendingnum',
       'unique'       => [ [ 'payunique' ] ],
-      'index'        => [ [ 'custnum' ], [ 'status' ], ],
+      'index'        => [ [ 'custnum' ], [ 'status' ],['agent_transid'], ['paynum'], ['void_paynum'], ['jobnum'] ],
       'foreign_keys' => [
                           { columns    => [ 'custnum' ],
                             table      => 'cust_main',


### PR DESCRIPTION
migration pains with our process.  Also a reminder that in PG, creating
a foreign key does not create an index

also added a jobnum index, as deleting from queue begins doing a full
table scan on cust_pay_pending because of the foreign key. For systems
that use the pending system, that becomes very expensive. Key makes it
run correctly.
