### PR TITLE
Geo::StreetAddress::US recommends using parse_location instead

### DIFF
--- a/FS/FS/TaxEngine/avalara.pm
+++ b/FS/FS/TaxEngine/avalara.pm
@@ -92,7 +92,7 @@ sub build_request {
   my $our_address = join(' ', 
     $conf->config('company_address', $cust_main->agentnum)
   );
-  my $company_address = Geo::StreetAddress::US->parse_address($our_address);
+  my $company_address = Geo::StreetAddress::US->parse_location($our_address);
   my $address1 = join(' ', grep $_, @{$company_address}{qw(
       number prefix street type suffix
   )});

--- a/FS/FS/part_export/nena2.pm
+++ b/FS/FS/part_export/nena2.pm
@@ -262,7 +262,7 @@ sub data {
 
   Geo::StreetAddress::US->avoid_redundant_street_type(1);
 
-  my $location_hash = Geo::StreetAddress::US->parse_address(
+  my $location_hash = Geo::StreetAddress::US->parse_location(
     uc( join(', ',  $full_address,
                     $cust_location->city,
                     $cust_location->state,
@@ -280,7 +280,7 @@ sub data {
       }
     }
     # then parsing failed. Try again without the address2.
-    $location_hash = Geo::StreetAddress::US->parse_address(
+    $location_hash = Geo::StreetAddress::US->parse_location(
       uc( join(', ',
                     $cust_location->address1,
                     $cust_location->city,


### PR DESCRIPTION
I had an issue parsing my address using the new avalara tax module.  After digging I found that parse_address was not working where parse_location does.  Looking further into the Geo::StreetAddress::US module and its own perldoc recommends using parse_location.