### PR TITLE
New billing event actions: Per-invoice suspend and cancel

### DIFF
--- a/FS/FS/cust_bill.pm
+++ b/FS/FS/cust_bill.pm
@@ -629,6 +629,23 @@ sub num_cust_event {
 
 Returns the customer (see L<FS::cust_main>) for this invoice.
 
+=item suspend
+
+Suspends all unsuspended packages (see L<FS::cust_pkg>) for this invoice
+
+Returns a list: an empty list on success or a list of errors.
+
+=cut
+
+sub suspend {
+  my $self = shift;
+
+  grep { $_->suspend(@_) } 
+  grep { $_->getfield('cancel') } 
+  $self->cust_pkg;
+
+}
+
 =item cust_suspend_if_balance_over AMOUNT
 
 Suspends the customer associated with this invoice if the total amount owed on

--- a/FS/FS/part_event/Action/cust_bill_cancel.pm
+++ b/FS/FS/part_event/Action/cust_bill_cancel.pm
@@ -1,0 +1,35 @@
+package FS::part_event::Action::cust_bill_cancel;
+
+use strict;
+use base qw( FS::part_event::Action );
+
+sub description { 'Cancel packages on this invoice'; }
+
+sub eventtable_hashref {
+  { 'cust_bill' => 1 };
+}
+
+sub option_fields {
+  (
+    'reasonnum'    => { 'label'        => 'Reason',
+                        'type'         => 'select-reason',
+                        'reason_class' => 'C',
+                      },
+  );
+}
+
+sub default_weight { 10; }
+
+sub do_action {
+  my( $self, $cust_bill ) = @_;
+
+  my @err = $cust_bill->cancel(
+    'reason'  => $self->option('reasonnum'),
+  );
+
+  die join(' / ', @err) if scalar(@err);
+
+  return '';
+}
+
+1;

--- a/FS/FS/part_event/Action/cust_bill_suspend.pm
+++ b/FS/FS/part_event/Action/cust_bill_suspend.pm
@@ -1,0 +1,41 @@
+package FS::part_event::Action::cust_bill_suspend;
+
+use strict;
+use base qw( FS::part_event::Action );
+
+sub description { 'Suspend packages on this invoice'; }
+
+sub eventtable_hashref {
+  { 'cust_bill' => 1 };
+}
+
+sub option_fields {
+  (
+    'reasonnum'    => { 'label'        => 'Reason',
+                        'type'         => 'select-reason',
+                        'reason_class' => 'S',
+                      },
+    'suspend_bill' => { 'label' => 'Continue recurring billing while suspended',
+                        'type'  => 'checkbox',
+                        'value' => 'Y',
+                      },
+  );
+}
+
+sub default_weight { 10; }
+
+sub do_action {
+  my( $self, $cust_bill ) = @_;
+
+  my @err = $cust_bill->suspend(
+    'reason'  => $self->option('reasonnum'),
+    'options' => { 'suspend_bill' => $self->option('suspend_bill') },
+  );
+
+  die join(' / ', @err) if scalar(@err);
+
+  return '';
+
+}
+
+1;


### PR DESCRIPTION
Issuing the pull request before any heavy testing to see if you agree with the overall approach.  Basically allows for suspensions/cancellations of packages on a specific invoice, and then creates the appropriate cust_bill part_event Action. 

This is useful for us where we would like to automate suspension/cancellation no customer-wide, but only on the packages applicable to a specific overdue bill.