### PR TITLE
Fix bug where FS::class_Common->_category_table() returned inaccurate table name

### DIFF
--- a/FS/FS/class_Common.pm
+++ b/FS/FS/class_Common.pm
@@ -122,14 +122,15 @@ sub _target_table {
 
 sub _target_column { 'classnum'; }
 
-use vars qw( $_category_table );
+use vars qw( %_category_table );
 sub _category_table {
-  return $_category_table if $_category_table;
   my $self = shift;
-  $_category_table = $self->table;
-  $_category_table =~ s/class/category/ # s/_class$/_category/
-    or die "can't determine an automatic category table for $_category_table";
-  $_category_table;
+  return $_category_table{ ref $self } ||= do {
+    my $category_table = $self->table;
+    $category_table =~ s/class/category/ # s/_class$/_category/
+      or die "can't determine an automatic category table for $category_table";
+    $category_table;
+  }
 }
 
 =head1 BUGS


### PR DESCRIPTION
This pull request pertains to FS::class_Common where $_category_table was updated to be a hash that maps packages to category tables. A bug was found where periodically "part_svc_category" was returned from the _category_table method when FS::part_pkg->categoryname() was called. This resulted in FS::Record::qsearch dying due to the part_svc_category table not existing.

It was debated with my co-workers to "return $self->{_category_table'} ||= do{" instead. The issue that I had with this was it restricts the information at object level. The method I implement here allows the data to still be accessed and shared at a class level yet prevents collision.

Please feel free to let me know if there are any question, concerns, or any adjustments that should be made. Thanks.