### PR TITLE
Fixed bug: Replaced $FS::CurrentUser->CurrentUser with $FS::CurrentUser::CurrentUser

### DIFF
--- a/FS/FS/cust_main.pm
+++ b/FS/FS/cust_main.pm
@@ -1856,7 +1856,7 @@ sub check {
   return "You are not permitted to create complimentary accounts."
     if ! $self->custnum
     && $self->complimentary eq 'Y'
-    && ! $FS::CurrentUser->CurrentUser->access_right('Complimentary customer');
+    && ! $FS::CurrentUser::CurrentUser->access_right('Complimentary customer');
 
   if ( $self->paydate eq '' || $self->paydate eq '-' ) {
     return "Expiration date required"


### PR DESCRIPTION
This was causing problems when running freeside-setup:

Can't call method "CurrentUser" on an undefined value at .../cust_main.pm line 1867.

because it's not a method, but a variable.