### PR TITLE
Don't attempt to call FS::TicketSystem->queues() if no ticket_system configured

### DIFF
--- a/FS/FS/part_export/rt_ticket.pm
+++ b/FS/FS/part_export/rt_ticket.pm
@@ -36,6 +36,7 @@ my %queue_select = (
     $queues{$_[0]};
   },
   option_values => sub {
+    return if $FS::Record::conf->config('ticket_system') eq '';
     %queues = (0 => '', FS::TicketSystem->queues());
     sort {$queues{$a} cmp $queues{$b}} keys %queues;
   },


### PR DESCRIPTION
With ticket_system = '' in config, adding a new part_export results in a nasty error because of the FS::TicketSystem AUTOLOAD that tries to accommodate the queues() call. Not 100% sure this is the best fix, but it appears to work.  