### PR TITLE
restored $dbh->commit to part_pkg_link->insert

### DIFF
--- a/FS/FS/part_pkg_link.pm
+++ b/FS/FS/part_pkg_link.pm
@@ -129,7 +129,7 @@ sub insert {
 
     return $error if $error;
   }
-
+  $dbh->commit;
   return;
 }
 


### PR DESCRIPTION
After some confused interactions in the interface in which supplemental packages were being created but not properly linked, one of our developers did a little digging and discovered that `part_pkg_link->insert` was setting autocommit to 0 but never called `$dbh->commit`.  After a little bit of bisecting this appears to have just been an oversight in commit 67cef14 from Nov when the insert was first added to override the default FS::Record one.  This is a one line fix to restore the expected behavior.