### PR TITLE
Calc discount rounding

### DIFF
--- a/FS/FS/part_pkg/discount_Mixin.pm
+++ b/FS/FS/part_pkg/discount_Mixin.pm
@@ -40,8 +40,8 @@ sub calc_discount {
   my($self, $cust_pkg, $sdate, $details, $param ) = @_;
   my $conf = new FS::Conf;
 
-  my $br = $self->base_recur_permonth($cust_pkg, $sdate);
-  $br += $param->{'override_charges'} if $param->{'override_charges'};
+  my $br_permonth = $self->base_recur_permonth($cust_pkg, $sdate);
+  $br_permonth += $param->{'override_charges'} if $param->{'override_charges'};
  
   my $tot_discount = 0;
   #UI enforces just 1 for now, will need ordering when they can be stacked
@@ -83,7 +83,7 @@ sub calc_discount {
     my $amount = 0;
     $amount += $discount->amount
         if $cust_pkg->pkgpart == $param->{'real_pkgpart'};
-    $amount += sprintf('%.2f', $discount->percent * $br / 100 );
+    $amount += sprintf('%.2f', $discount->percent * $br_permonth / 100 );
     my $chg_months = defined($param->{'months'}) ?
                       $param->{'months'} :
                       $cust_pkg->part_pkg->freq;
@@ -133,7 +133,7 @@ sub calc_discount {
         };
       }
 
-      $amount = min($amount, $br);
+      $amount = min($amount, $br_permonth);
       $amount *= $months;
     }
 
@@ -147,9 +147,9 @@ sub calc_discount {
         && !defined $param->{'setup_charge'}
        )
     {
-      $discount_left = $br - $amount;
+      $discount_left = $br_permonth - $amount;
       if ( $discount_left < 0 ) {
-        $amount = $br;
+        $amount = $br_permonth;
         $param->{'discount_left_setup'}{$discount->discountnum} = 
           0 - $discount_left;
       }
@@ -188,7 +188,7 @@ sub calc_discount {
     #}
 
     #push @$details, $d;
-    #push @$details, sprintf( $format, $money_char, $br );
+    #push @$details, sprintf( $format, $money_char, $br_permonth );
 
   }
 

--- a/FS/FS/part_pkg/discount_Mixin.pm
+++ b/FS/FS/part_pkg/discount_Mixin.pm
@@ -42,7 +42,10 @@ sub calc_discount {
 
   my $br_permonth = $self->base_recur_permonth($cust_pkg, $sdate);
   $br_permonth += $param->{'override_charges'} if $param->{'override_charges'};
- 
+
+  my $br = $self->base_recur($cust_pkg, $sdate);
+  $br += $param->{'override_charges'} * ($cust_pkg->part_pkg->freq || 0) if $param->{'override_charges'};
+
   my $tot_discount = 0;
   #UI enforces just 1 for now, will need ordering when they can be stacked
 
@@ -83,7 +86,7 @@ sub calc_discount {
     my $amount = 0;
     $amount += $discount->amount
         if $cust_pkg->pkgpart == $param->{'real_pkgpart'};
-    $amount += sprintf('%.2f', $discount->percent * $br_permonth / 100 );
+    $amount += sprintf('%.2f', $discount->percent * $br_permonth / 100 ); # FIXME: should this use $br / $freq to avoid rounding errors?
     my $chg_months = defined($param->{'months'}) ?
                       $param->{'months'} :
                       $cust_pkg->part_pkg->freq;
@@ -133,8 +136,7 @@ sub calc_discount {
         };
       }
 
-      $amount = min($amount, $br_permonth);
-      $amount *= $months;
+      $amount = min($amount * $months, $br);
     }
 
     $amount = sprintf('%.2f', $amount + 0.00000001 ); #so 1.005 rounds to 1.01
@@ -147,9 +149,9 @@ sub calc_discount {
         && !defined $param->{'setup_charge'}
        )
     {
-      $discount_left = $br_permonth - $amount;
+      $discount_left = $br_permonth - $amount; # FIXME: $amount is no longer permonth at this point!
       if ( $discount_left < 0 ) {
-        $amount = $br_permonth;
+        $amount = $br_permonth; # FIXME: seems like this should *= $months
         $param->{'discount_left_setup'}{$discount->discountnum} = 
           0 - $discount_left;
       }


### PR DESCRIPTION
I encountered a bug when trying to apply a discount greater than the recur_fee of the package it is applied to.  This can occur with any package where the rounded permonth rate does not match the full term rate or in other words: $base_recur != round($base_recur / $freq, 2) * $freq.

So for instance, a package with a price of $14.99 (base_recur_permonth becomes $1.25).  If you try to apply a discount that is $1.25/month then calc_discount tries to apply a discount of $1.25 * 12 = $15.00 which then fails because calc_recur returns -$0.01.

There is already code that tries to handle discounts that are greater than the recur_fee of the package but that only works when the recur_fee is a round multiple of the freq of the package.

I adjusted the guard that tried to ensure that the discount amount was greater than the base_recur amount.  It now does this BEFORE rounding to the penny on a per monthly basis, preventing the possibility of being off by up to $freq pennies.  The important change is here:

-      $amount = min($amount, $br);
-      $amount *= $months;
+      $amount = min($amount * $months, $br);

where $br is now the full base_recur, not the base_recur_permonth

I also added some comments about other places in the same code that seemed potentially problematic to me but that weren't specifically triggering this bug.  I can remove those if needed.