### PR TITLE
Add ability to store securely hashed sessionkeys

### DIFF
--- a/FS/FS/Conf.pm
+++ b/FS/FS/Conf.pm
@@ -832,6 +832,13 @@ my $validate_email = sub { $_[0] =~
   },
 
   {
+    'key'         => 'hashsalt',
+    'section'     => 'billing',
+    'description' => 'Hash salt string (enables hashing of session keys/cookies)',
+    'type'        => 'text',
+  },
+
+  {
     'key'         => 'encryption',
     'section'     => 'billing',
     'description' => 'Enable encryption of credit cards and echeck numbers',

--- a/FS/FS/Record.pm
+++ b/FS/FS/Record.pm
@@ -74,6 +74,7 @@ FS::UID->install_callback( sub {
   my $nw_coords = $conf->exists('geocode-require_nw_coordinates');
   $lat_lower = $nw_coords ? 1 : -90;
   $lon_upper = $nw_coords ? -1 : 180;
+  $conf_hashsalt             = $conf->config('hashsalt');
 
   $File::CounterFile::DEFAULT_DIR = $conf->base_dir . "/counters.". datasrc;
 

--- a/FS/FS/Record.pm
+++ b/FS/FS/Record.pm
@@ -1583,18 +1583,6 @@ sub replace {
     }
   }
 
-  # SHA256 hash for replace
-  $saved = {};
-  if (    $conf_hashsalt
-       && defined(eval '@FS::'. $new->table . '::hashed_fields')
-       && scalar( eval '@FS::'. $new->table . '::hashed_fields')
-  ) {
-    foreach my $field (eval '@FS::'. $new->table . '::hashed_fields') {
-      $saved->{$field} = $new->getfield($field);
-      $new->setfield($field, sha256_hex($new->getfield($field).$conf_hashsalt));
-    }
-  }
-
   #my @diff = grep $new->getfield($_) ne $old->getfield($_), $old->fields;
   my %diff = map { ($new->getfield($_) ne $old->getfield($_))
                    ? ($_, $new->getfield($_)) : () } $old->fields;

--- a/FS/FS/access_user_session.pm
+++ b/FS/FS/access_user_session.pm
@@ -3,6 +3,8 @@ use base qw( FS::Record );
 
 use strict;
 
+our @hashed_fields = ('sessionkey');
+
 =head1 NAME
 
 FS::access_user_session - Object methods for access_user_session records

--- a/FS/t/Record.t
+++ b/FS/t/Record.t
@@ -1,5 +1,135 @@
-BEGIN { $| = 1; print "1..1\n" }
-END {print "not ok 1\n" unless $loaded;}
-use FS::Record;
-$loaded=1;
-print "ok 1\n";
+use strict;
+use warnings;
+use FS::Conf;
+use Data::Dumper qw( Dumper );
+use FS::UID qw( adminsuidsetup );
+use Digest::SHA qw(sha256_hex);
+use Test::More tests => 26;
+
+# Stock freeside does equivalent of the following
+BEGIN { use_ok('FS::Record') }
+
+# If adminuser passed in, assume this is being run in foreground
+my $freeside_uid = getpwnam('freeside');
+my $adminuser = shift || '';
+if (!length $adminuser) {
+    note <<"USAGE";
+Syntax for longer user-initiated tests:
+    prove $0 :: [admin-user_name]
+        OR
+    perl  $0 [admin-user_name]
+
+USAGE
+}
+
+SKIP: {
+    skip 'test(s) if not run as freeside user or if DB adminuser unspecified', 25 
+        if ($< != $freeside_uid) || !length($adminuser);
+
+    require_ok('FS::access_user_session');
+
+    my $dbh = adminsuidsetup $adminuser;
+
+    my $conf = FS::Conf->new;
+
+    # 1. Without salt
+    local $FS::Record::conf_hashsalt = '';
+    my $cookie = 'this is a test '. time();
+    my $record1 = new FS::access_user_session {
+        usernum => 3,
+        sessionkey => $cookie,
+        start_date => 0,
+    };
+
+    my $error = $record1->insert;
+    ok(!$error, 'Insert unhashed record in access_user_session') or diag explain $error,$record1;
+    my @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    ok(scalar @records == 1,'qsearch finds single matching record just inserted');
+    cmp_ok($records[0]->sessionkey,'eq',$cookie,'Unhashed sessionkey matches');
+
+    my $record2 = new FS::access_user_session { # Record 2 will replace record 1
+        usernum => 3,
+        sessionkey => $cookie,
+        start_date => 2,
+        sessionnum => $record1->{'Hash'}->{'sessionnum'},	
+    };
+    $error = $record2->replace($record1);
+    ok(!$error, 'Replace unhashed record in access_user_session with different start_date') or diag explain $error,$record2,$record1;
+    @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    ok(scalar @records == 1,'qsearch finds single matching record just replaced');
+    cmp_ok($records[0]->sessionkey,'eq',$cookie,'Unhashed sessionkey matches after replacing');
+    cmp_ok($records[0]->start_date,'==',2,'Replaced record has new start_date');
+
+    # 2. First salt
+    local $FS::Record::conf_hashsalt = 'test it'; 
+    my $saltrecord1 = new FS::access_user_session {
+        usernum => 3,
+        sessionkey => $cookie,
+        start_date => 0,
+    };
+
+    $error = $saltrecord1->insert;
+    ok(!$error, 'Insert record in access_user_session with first salt') or diag explain $error,$saltrecord1;
+    my $shacookie1 = sha256_hex($cookie.$FS::Record::conf_hashsalt);
+    @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    ok(scalar @records == 1,'qsearch finds single matching record just inserted with first salt');
+    cmp_ok($records[0]->sessionkey,'eq',$shacookie1,'First salted sessionkey matches');
+
+    my $saltrecord2 = new FS::access_user_session {
+        usernum => 3,
+        sessionkey => $cookie,
+        start_date => 2,	# Increment start date for replace
+        sessionnum => $saltrecord1->{'Hash'}->{'sessionnum'},	
+    };
+    $error = $saltrecord2->replace($saltrecord1);
+    ok(!$error, 'Replace hashed record (salted with 1st salt) in access_user_session with different start_date') or diag explain $error,$saltrecord2,$saltrecord1;
+    @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    ok(scalar @records == 1,'qsearch finds single matching record (salted with 1st salt) just replaced');
+    cmp_ok($records[0]->sessionkey,'eq',$shacookie1,'First Hashed sessionkey matches');
+    cmp_ok($records[0]->start_date,'==',2,'Replaced record has new start date');
+
+    # 3. Salt no. 2
+    local $FS::Record::conf_hashsalt = 'test it2'; 
+    my $salt2record1 = new FS::access_user_session {
+    usernum => 3,
+    sessionkey => $cookie,
+    start_date => 0,
+    };
+
+    $error = $salt2record1->insert;
+    ok(!$error, 'Insert record in access_user_session with 2nd salt') or diag explain $error,$salt2record1;
+    my $shacookie2 = sha256_hex($cookie.$FS::Record::conf_hashsalt);
+    @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    ok(scalar @records == 1,'qsearch finds single matching record (salted with 2nd salt) just inserted with second salt');
+    cmp_ok($records[0]->sessionkey,'eq',$shacookie2,'Second salted sessionkey matches (salted with 2nd salt) matches');
+
+    my $salt2record2 = new FS::access_user_session {
+        usernum => 3,
+        sessionkey => $cookie,
+        start_date => 2,	# Increment start date for replace
+        sessionnum => $salt2record1->{'Hash'}->{'sessionnum'},	
+    };
+    $error = $salt2record2->replace($salt2record1);
+    ok(!$error, 'Replace 2nd hashed record (salted with 2nd salt) access_user_session with different start_date') or diag explain $error,$salt2record2,$salt2record1;
+    @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    ok(scalar @records == 1,'qsearch finds single matching record (salted with 2nd salt) just replaced');
+    cmp_ok($records[0]->sessionkey,'eq',$shacookie2,'2nd hashed cookie matches');
+    cmp_ok($records[0]->start_date,'==',2,'Replaced record has new start date');
+
+    # 4. No salt ... again
+    # Update the unsalted (unhashed) record in step 1. 
+    local $FS::Record::conf_hashsalt = ''; 
+    my $record3 = new FS::access_user_session {
+        usernum => 3,
+        sessionkey => $cookie,
+        start_date => 4,	# Increment start date for replace
+        sessionnum => $record1->{'Hash'}->{'sessionnum'},	
+    };
+    $error = $record3->replace($record2);
+    ok(!$error, 'Replace unhashed record (2nd time around) in access_user_session with different start_date') or diag explain $error,$record3,$record2;
+    @records = FS::Record::qsearch( access_user_session => { sessionkey => $cookie } );
+    cmp_ok($records[0]->sessionkey,'eq',$cookie,'2nd time around, able to replace original plain cookie/sessionnum');
+    cmp_ok($records[0]->start_date,'==',4,'2nd time around, replaced record has even newer start_date');
+
+}
+


### PR DESCRIPTION
Freeside currently stores sessionkeys on the server in plaintext. Storing them as salted hashes would help be more PCI-compliant.

This pull request implements the ability to optionally store sessionkeys as salted SHA256 hashes.

It is implemented as follows:
- A new hashsalt key is added to FS::Conf. A zero-length hashsalt value causes freeside to behave unchanged--no hashing takes place.
- If the hashsalt is present as a string of length > 0, hashing is enabled.
- Cookies continue to be stored on the browser in plaintext.
- If the field name is 'sessionkey' (specified in the "our" variable @hashed_fields in access_user_session.pm and visible in FS::Record), qsearch will search the server's database for the salted/hashed version of the sessionkey (but only when configured on FS::Conf ...)
- Similarly, when adding new sessionkeys to the database (FS::Record) will hash the value as it is inserted into the database.
- One other non-related change: In Encrypt before the database, I rearranged the tests to test $conf_encryption before checking for the definition of ...::encrypted_fields.

First-time Transition to using the hashed sessionkey:
On an installation that includes this patch:
- The administrator specifies a hashsalt value.
- The next time s/he sends a cookie to the server, it will say "Bad Cookie" and force a new login. (This also applies to any users that might be logged in to Freeside.)

FS/t/Record.t test case:
- We modified the test case for verification on our installation.
- On an unattended run of the test suite, the result should be the same as the existing test, verifying that FS::Record loads.
- If run as the freeside user and a valid adminuser is specified (as prompted in the USAGE note), 10 additional tests will test the insertion and retrieval of the sessionkey with and without the salted hash.

