### PR TITLE
create fk_methods_init and load_schema

### DIFF
--- a/FS/FS/UID.pm
+++ b/FS/FS/UID.pm
@@ -14,7 +14,7 @@ use IO::File;
 use FS::CurrentUser;
 
 @EXPORT_OK = qw( checkeuid checkruid cgi setcgi adminsuidsetup forksuidsetup
-                 preuser_setup
+                 preuser_setup load_schema
                  getotaker dbh datasrc getsecrets driver_name myconnect
                );
 
@@ -113,6 +113,14 @@ sub env_setup {
 
 }
 
+sub load_schema {
+  warn "$me loading schema\n" if $DEBUG;
+  getsecrets() unless $datasrc;
+  use FS::Schema qw(reload_dbdef dbdef);
+  reload_dbdef("$conf_dir/dbdef.$datasrc")
+    unless $FS::Schema::setup_hack;
+}
+
 sub db_setup {
   croak "Not running uid freeside (\$>=$>, \$<=$<)\n" unless checkeuid();
 
@@ -121,10 +129,7 @@ sub db_setup {
 
   warn "$me forksuidsetup connected to database with handle $dbh\n" if $DEBUG;
 
-  warn "$me forksuidsetup loading schema\n" if $DEBUG;
-  use FS::Schema qw(reload_dbdef dbdef);
-  reload_dbdef("$conf_dir/dbdef.$datasrc")
-    unless $FS::Schema::setup_hack;
+  load_schema();
 
   warn "$me forksuidsetup deciding upon config system to use\n" if $DEBUG;
 

--- a/htetc/handler.pl
+++ b/htetc/handler.pl
@@ -10,6 +10,12 @@ use FS::Conf;
 
 $FS::Conf::conf_cache_enabled = 1; # enable FS::Conf caching for performance
 
+# Preload to share in mod_perl parent for performance
+use FS::UID qw(load_schema);
+load_schema();
+use FS::Record qw(fk_methods_init);
+fk_methods_init;
+
 if ( %%%RT_ENABLED%%% ) {
 
   require RT;


### PR DESCRIPTION
 so that they can be called pre-fork by mod_perl startup scripts

Example usage in a startup script
```
use FS::UID qw(load_schema);
load_schema();
use FS::Record qw(fk_methods_init);
fk_methods_init;
```

My testing VMs are less than stellar, but this tweak saves a full 2 seconds per page view in my test environment.

You don't need to do the mod_perl init to get benefit, but adding the init portion saves the 2 seconds on apache child creating as well...