### PR TITLE
Invoice and payment void reasons

### DIFF
--- a/FS/FS/Schema.pm
+++ b/FS/FS/Schema.pm
@@ -2505,6 +2505,7 @@ sub tables_hashref {
         #void fields
         'void_date',  @date_type,                  '', '', 
         'reason',      'varchar', 'NULL', $char_d, '', '', 
+        'reasonnum',       'int', 'NULL',      '', '', '', 
         'void_usernum',    'int', 'NULL',      '', '', '',
       ],
       'primary_key'  => 'paynum',
@@ -2525,6 +2526,9 @@ sub tables_hashref {
                           },
                           { columns    => [ 'gatewaynum' ],
                             table      => 'payment_gateway',
+                          },
+                          { columns    => [ 'reasonnum' ],
+                            table      => 'reason',
                           },
                           { columns    => [ 'void_usernum' ],
                             table      => 'access_user',

--- a/FS/FS/Schema.pm
+++ b/FS/FS/Schema.pm
@@ -735,8 +735,9 @@ sub tables_hashref {
 
         #void fields
         'void_date', @date_type, '', '', 
-        'reason',    'varchar',   'NULL', $char_d, '', '', 
-        'void_usernum',   'int', 'NULL', '', '', '',
+        'reason',     'varchar', 'NULL', $char_d, '', '', 
+        'reasonnum',      'int', 'NULL',      '', '', '',
+        'void_usernum',   'int', 'NULL',      '', '', '',
       ],
       'primary_key'  => 'invnum',
       'unique'       => [ [ 'custnum', 'agent_invid' ] ], #agentnum?  huh
@@ -749,6 +750,9 @@ sub tables_hashref {
                           },
                           { columns    => [ 'statementnum' ],
                             table      => 'cust_statement', #_void? both?
+                          },
+                          { columns    => [ 'reasonnum' ],
+                            table      => 'reason',
                           },
                           { columns    => [ 'void_usernum' ],
                             table      => 'access_user',
@@ -1197,8 +1201,9 @@ sub tables_hashref {
         'feepart',              'int', 'NULL',      '', '', '',
         #void fields
         'void_date', @date_type, '', '', 
-        'reason',    'varchar',   'NULL', $char_d, '', '', 
-        'void_usernum',   'int', 'NULL', '', '', '',
+        'reason',     'varchar', 'NULL', $char_d, '', '', 
+        'reasonnum',      'int', 'NULL',      '', '', '',
+        'void_usernum',   'int', 'NULL',      '', '', '',
       ],
       'primary_key'  => 'billpkgnum',
       'unique'       => [],
@@ -1208,6 +1213,9 @@ sub tables_hashref {
       'foreign_keys' => [
                           { columns    => [ 'invnum' ],
                             table      => 'cust_bill_void',
+                          },
+                          { columns    => [ 'reasonnum' ],
+                            table      => 'reason',
                           },
                           #pkgnum 0 and -1 are used for special things
                           #{ columns    => [ 'pkgnum' ],

--- a/FS/FS/Upgrade.pm
+++ b/FS/FS/Upgrade.pm
@@ -344,6 +344,11 @@ sub upgrade_data {
     #customer credits
     'cust_credit' => [],
 
+    # reason / void_reason migration to reasonnum / void_reasonnum
+    'cust_credit_void' => [],
+    'cust_bill_void' => [],
+    'cust_bill_pkg_void' => [],
+
     #duplicate history records
     'h_cust_svc'  => [],
 

--- a/FS/FS/cust_bill_pkg_void.pm
+++ b/FS/FS/cust_bill_pkg_void.pm
@@ -1,5 +1,5 @@
 package FS::cust_bill_pkg_void;
-use base qw( FS::TemplateItem_Mixin FS::Record );
+use base qw( FS::TemplateItem_Mixin FS::reason_Mixin FS::Record );
 
 use strict;
 use FS::Record qw( qsearch qsearchs dbh fields );
@@ -104,6 +104,13 @@ unitrecur
 
 hidden
 
+=item reason 
+
+freeform string (deprecated)
+
+=item reasonnum 
+
+reason for voiding the payment (see L<FS::reson>)
 
 =back
 
@@ -133,6 +140,10 @@ sub discount_table          { 'cust_bill_pkg_discount_void'; }
 
 Adds this record to the database.  If there is an error, returns the error,
 otherwise returns false.
+
+=item reason
+
+Returns the text of the associated void reason (see L<FS::reason>) for this.
 
 =item unvoid 
 
@@ -242,6 +253,8 @@ sub check {
     || $self->ut_moneyn('unitrecur')
     || $self->ut_enum('hidden', [ '', 'Y' ])
     || $self->ut_numbern('feepart')
+    || $self->ut_textn('reason')
+    || $self->ut_foreign_keyn('reasonnum', 'reason', 'reasonnum')
   ;
   return $error if $error;
 

--- a/FS/FS/cust_bill_pkg_void.pm
+++ b/FS/FS/cust_bill_pkg_void.pm
@@ -2,6 +2,7 @@ package FS::cust_bill_pkg_void;
 use base qw( FS::TemplateItem_Mixin FS::reason_Mixin FS::Record );
 
 use strict;
+use vars qw( $me $DEBUG );
 use FS::Record qw( qsearch qsearchs dbh fields );
 use FS::cust_bill_void;
 use FS::cust_bill_pkg_detail;
@@ -12,6 +13,9 @@ use FS::cust_bill_pkg_fee;
 use FS::cust_bill_pkg_tax_location;
 use FS::cust_bill_pkg_tax_rate_location;
 use FS::cust_tax_exempt_pkg;
+
+$me = '[ FS::cust_bill_pkg_void ]';
+$DEBUG = 0;
 
 =head1 NAME
 
@@ -277,6 +281,18 @@ sub cust_bill {
 sub cust_bill_pkg_fee {
   my $self = shift;
   qsearch( 'cust_bill_pkg_fee_void', { 'billpkgnum' => $self->billpkgnum } );
+}
+
+
+# _upgrade_data
+#
+# Used by FS::Upgrade to migrate to a new database.
+sub _upgrade_data {  # class method
+  my ($class, %opts) = @_;
+
+  warn "$me upgrading $class\n" if $DEBUG;
+
+  $class->_upgrade_reasonnum(%opts);
 }
 
 =back

--- a/FS/FS/cust_bill_void.pm
+++ b/FS/FS/cust_bill_void.pm
@@ -1,5 +1,6 @@
 package FS::cust_bill_void;
-use base qw( FS::Template_Mixin FS::cust_main_Mixin FS::otaker_Mixin FS::Record );
+use base qw( FS::Template_Mixin FS::cust_main_Mixin FS::otaker_Mixin
+             FS::reason_Mixin FS::Record );
 
 use strict;
 use FS::Record qw( qsearch qsearchs dbh fields );
@@ -82,9 +83,13 @@ promised_date
 
 void_date
 
-=item reason
+=item reason 
 
-reason
+freeform string (deprecated)
+
+=item reasonnum 
+
+reason for voiding the payment (see L<FS::reson>)
 
 =item void_usernum
 
@@ -216,6 +221,7 @@ sub check {
     || $self->ut_numbern('void_date')
     || $self->ut_textn('reason')
     || $self->ut_numbern('void_usernum')
+    || $self->ut_foreign_keyn('reasonnum', 'reason', 'reasonnum')
   ;
   return $error if $error;
 
@@ -258,6 +264,10 @@ sub void_access_user {
 =item cust_main
 
 =item cust_bill_pkg
+
+=item reason
+
+Returns the text of the associated void reason (see L<FS::reason>) for this.
 
 =cut
 

--- a/FS/FS/cust_bill_void.pm
+++ b/FS/FS/cust_bill_void.pm
@@ -3,11 +3,15 @@ use base qw( FS::Template_Mixin FS::cust_main_Mixin FS::otaker_Mixin
              FS::reason_Mixin FS::Record );
 
 use strict;
+use vars qw( $me $DEBUG );
 use FS::Record qw( qsearch qsearchs dbh fields );
 use FS::cust_statement;
 use FS::access_user;
 use FS::cust_bill_pkg_void;
 use FS::cust_bill;
+
+$me = '[ FS::cust_bill_void ]';
+$DEBUG = 0;
 
 =head1 NAME
 
@@ -348,6 +352,17 @@ sub search_sql_where {
 =cut
 
 sub enable_previous { 0 }
+
+# _upgrade_data
+#
+# Used by FS::Upgrade to migrate to a new database.
+sub _upgrade_data {  # class method
+  my ($class, %opts) = @_;
+
+  warn "$me upgrading $class\n" if $DEBUG;
+
+  $class->_upgrade_reasonnum(%opts);
+}
 
 =back
 

--- a/FS/FS/cust_credit.pm
+++ b/FS/FS/cust_credit.pm
@@ -408,7 +408,7 @@ sub void {
   my $cust_credit_void = new FS::cust_credit_void ( {
       map { $_ => $self->get($_) } $self->fields
     } );
-  $cust_credit_void->set('void_reasonnum', $reason->reasonnum);
+  $cust_credit_void->set('void_reasonnum', $reason->reasonnum) if $reason;
   my $error = $cust_credit_void->insert;
   if ( $error ) {
     $dbh->rollback if $oldAutoCommit;

--- a/FS/FS/cust_credit_void.pm
+++ b/FS/FS/cust_credit_void.pm
@@ -2,11 +2,15 @@ package FS::cust_credit_void;
 use base qw( FS::otaker_Mixin FS::cust_main_Mixin FS::reason_Mixin FS::Record );
 
 use strict;
+use vars qw( $me $DEBUG );
 use FS::Record qw(qsearchs); # qsearch qsearchs);
 use FS::CurrentUser;
 use FS::access_user;
 use FS::cust_credit;
 use FS::UID qw( dbh );
+
+$me = '[ FS::cust_credit_void ]';
+$DEBUG = 0;
 
 =head1 NAME
 
@@ -188,6 +192,17 @@ sub void_reason {
   }
 
   return $reason_text;
+}
+
+# _upgrade_data
+#
+# Used by FS::Upgrade to migrate to a new database.
+sub _upgrade_data {    # class method
+    my ( $class, %opts ) = @_;
+
+    warn "$me upgrading $class\n" if $DEBUG;
+
+    $class->_upgrade_reasonnum(%opts);
 }
 
 =back

--- a/FS/FS/reason_Mixin.pm
+++ b/FS/FS/reason_Mixin.pm
@@ -6,18 +6,21 @@ use FS::Record qw( qsearch qsearchs dbdef );
 use FS::access_user;
 use FS::UID qw( dbh );
 use FS::reason;
+use FS::reason_type;
 
 our $DEBUG = 0;
 our $me = '[FS::reason_Mixin]';
 
 =item reason
 
-Returns the text of the associated reason (see L<FS::reason>) for this credit.
+Returns the text of the associated reason (see L<FS::reason>) for this credit /
+voided payment / voided invoice.
 
 =cut
 
 sub reason {
-  my ($self, $value, %options) = @_;
+  my $self = shift;
+
   my $reason_text;
   if ( $self->reasonnum ) {
     my $reason = FS::reason->by_key($self->reasonnum);
@@ -40,57 +43,101 @@ sub _upgrade_reasonnum {  # class method
   my $class = shift;
   my $table = $class->table;
 
-  if (defined dbdef->table($table)->column('reason')) {
+  if (   defined dbdef->table($table)->column('reason')
+      && defined dbdef->table($table)->column('reasonnum') )
+  {
 
     warn "$me Checking for unmigrated reasons\n" if $DEBUG;
 
-    my @cust_refunds = qsearch({ 'table'     => $table,
-                                 'hashref'   => {},
-                                 'extra_sql' => 'WHERE reason IS NOT NULL',
-                              });
-
-    if (scalar(grep { $_->getfield('reason') =~ /\S/ } @cust_refunds)) {
-      warn "$me Found unmigrated reasons\n" if $DEBUG;
-      my $hashref = { 'class' => 'F', 'type' => 'Legacy' };
-      my $reason_type = qsearchs( 'reason_type', $hashref );
-      unless ($reason_type) {
-        $reason_type  = new FS::reason_type( $hashref );
-        my $error   = $reason_type->insert();
-        die "$class had error inserting FS::reason_type into database: $error\n"
-          if $error;
-      }
-
-      $hashref = { 'reason_type' => $reason_type->typenum,
-                   'reason' => '(none)'
-                 };
-      my $noreason = qsearchs( 'reason', $hashref );
-      unless ($noreason) {
-        $hashref->{'disabled'} = 'Y';
-        $noreason = new FS::reason( $hashref );
-        my $error  = $noreason->insert();
-        die "can't insert legacy reason '(none)' into database: $error\n"
-          if $error;
-      }
-
-      foreach my $cust_refund ( @cust_refunds ) {
-        my $reason = $cust_refund->getfield('reason');
-        warn "Contemplating reason $reason\n" if $DEBUG > 1;
-        if ($reason =~ /\S/) {
-          $cust_refund->reason($reason, 'reason_type' => $reason_type->typenum)
-            or die "can't insert legacy reason $reason into database\n";
-        }else{
-          $cust_refund->reasonnum($noreason->reasonnum);
+    my @legacy_reason_records = qsearch(
+        {
+            'table'     => $table,
+            'hashref'   => {},
+            'extra_sql' => 'WHERE reason IS NOT NULL',
         }
+    );
 
-        $cust_refund->setfield('reason', '');
-        my $error = $cust_refund->replace;
+    if (scalar(grep { $_->getfield('reason') =~ /\S/ } @legacy_reason_records)) {
+      warn "$me Found unmigrated reasons\n" if $DEBUG;
 
-        warn "*** WARNING: error replacing reason in $class ".
-             $cust_refund->refundnum. ": $error ***\n"
-          if $error;
-      }
+      my $reason_type = _upgrade_get_legacy_reason_type($class, $table);
+      my $noreason = _upgrade_get_no_reason($class, $reason_type);
+
+      foreach my $record_to_upgrade (@legacy_reason_records) {
+          my $reason = $record_to_upgrade->getfield('reason');
+          warn "Contemplating reason $reason\n" if $DEBUG > 1;
+          if ( $reason =~ /\S/ ) {
+              my $reason = _upgrade_get_reason( $class, $reason, $reason_type );
+              $record_to_upgrade->reasonnum( $reason->reasonnum );
+          }
+          else {
+              $record_to_upgrade->reasonnum( $noreason->reasonnum );
+          }
+
+          $record_to_upgrade->setfield( 'reason', '' );
+          my $error = $record_to_upgrade->replace;
+
+          my $primary_key = $record_to_upgrade->primary_key;
+          warn "*** WARNING: error replacing reason in $class "
+            . $record_to_upgrade->get($primary_key)
+            . ": $error ***\n"
+            if $error;
+       }
     }
   }
+}
+
+# _upgrade_get_legacy_reason_type is class method supposed to be used only
+# within the reason_Mixin class which will either find or create a reason_type
+sub _upgrade_get_legacy_reason_type {
+ 
+    my $class = shift;
+    my $table = shift;
+
+    my $reason_class =
+      ( $table =~ /void/ ) ? 'X' : 'F';    # see FS::reason_type (%class_name)
+    my $reason_type_params = { 'class' => $reason_class, 'type' => 'Legacy' };
+    my $reason_type = qsearchs( 'reason_type', $reason_type_params );
+    unless ($reason_type) {
+        $reason_type = new FS::reason_type($reason_type_params);
+        my $error = $reason_type->insert();
+        die "$class had error inserting FS::reason_type into database: $error\n"
+           if $error;
+    }
+    return $reason_type;
+}
+
+# _upgrade_get_no_reason is class method supposed to be used only within the
+# reason_Mixin class which will either find or create a default (no reason)
+# reason
+sub _upgrade_get_no_reason {
+
+    my $class       = shift;
+    my $reason_type = shift;
+    return _upgrade_get_reason( $class, '(none)', $reason_type );
+}
+
+# _upgrade_get_reason is class method supposed to be used only within the
+# reason_Mixin class which will either find or create a reason
+sub _upgrade_get_reason {
+
+    my $class       = shift;
+    my $reason_text = shift;
+    my $reason_type = shift;
+
+    my $reason_params = {
+        'reason_type' => $reason_type->typenum,
+        'reason'      => $reason_text
+    };
+    my $reason = qsearchs( 'reason', $reason_params );
+    unless ($reason) {
+        $reason_params->{'disabled'} = 'Y';
+        $reason = new FS::reason($reason_params);
+        my $error = $reason->insert();
+        die "can't insert legacy reason '$reason_text' into database: $error\n"
+           if $error;
+     }
+    return $reason;
 }
 
 1;

--- a/FS/FS/reason_type.pm
+++ b/FS/FS/reason_type.pm
@@ -11,7 +11,7 @@ our %class_name = (
   'R' => 'credit',
   'S' => 'suspend',
   'F' => 'refund',
-  'X' => 'void credit',
+  'X' => 'void', # credit/invoice/payment
 );
 
 our %class_purpose = (  

--- a/httemplate/elements/menu.html
+++ b/httemplate/elements/menu.html
@@ -721,6 +721,10 @@ if ( $curuser->access_right('Configuration') ) {
   $config_billing{'separator5'} = ''; #its a separator!
   $config_billing{'Refund reasons'}  = [ $fsurl.'browse/reason.html?class=F', 'Refund reasons explain why a refund was issued.' ];
   $config_billing{'Refund reason types'}  = [ $fsurl.'browse/reason_type.html?class=F', 'Refund reason types define groups of reasons.' ];
+
+  $config_billing{'separator6'} = ''; #its a separator!
+  $config_billing{'Void reasons'}  = [ $fsurl.'browse/reason.html?class=X', 'Void reasons explain why a void was issued.' ];
+  $config_billing{'Void reason types'}  = [ $fsurl.'browse/reason_type.html?class=X', 'Void reason types define groups of reasons.' ];
 }
 
 #XXX also to be unified

--- a/httemplate/elements/tr-select-reason.html
+++ b/httemplate/elements/tr-select-reason.html
@@ -199,7 +199,7 @@ if ($class eq 'C') {
 } elsif ($class eq 'F') {
   $add_access_right = 'Add on-the-fly refund reason';
 } elsif ($class eq 'X') {
-  $add_access_right = 'Add on-the-fly void credit reason';
+  $add_access_right = 'Add on-the-fly void reason';
 } else {
   die "illegal class: $class";
 }

--- a/httemplate/misc/process/void-cust_bill.html
+++ b/httemplate/misc/process/void-cust_bill.html
@@ -1,6 +1,6 @@
 %if ( $error ) {
 %  $cgi->param('error', $error);
-<% $cgi->redirect(popurl(2). "void-cust_bill.html?". $cgi->query_string ) %>
+<% $cgi->redirect(popurl(2). "void-cust_bill.cgi?". $cgi->query_string ) %>
 %} else {
 <& /elements/header-popup.html, 'Invoice voided' &>
 <SCRIPT TYPE="text/javascript">

--- a/httemplate/misc/unapply-cust_credit.cgi
+++ b/httemplate/misc/unapply-cust_credit.cgi
@@ -1,4 +1,4 @@
-<% $cgi->redirect($p. "view/cust_main.cgi?". $custnum) %>
+<% $cgi->redirect($p. "view/cust_main.cgi?custnum=". $custnum. ";show=payment_history") %>
 <%init>
 
 die "access denied"

--- a/httemplate/misc/unapply-cust_pay.cgi
+++ b/httemplate/misc/unapply-cust_pay.cgi
@@ -1,4 +1,4 @@
-<% $cgi->redirect($p. "view/cust_main.cgi?". $custnum) %>
+<% $cgi->redirect($p. "view/cust_main.cgi?custnum=". $custnum. ";show=payment_history") %>
 <%init>
 
 die "access denied"

--- a/httemplate/misc/unvoid-cust_pay_void.cgi
+++ b/httemplate/misc/unvoid-cust_pay_void.cgi
@@ -1,7 +1,7 @@
 %if ( $error ) {
 %  errorpage($error);
 %} else {
-<% $cgi->redirect($p. "view/cust_main.cgi?". $custnum) %>
+<% $cgi->redirect($p. "view/cust_main.cgi?custnum=". $custnum. ";show=payment_history") %>
 %}
 <%init>
 

--- a/httemplate/misc/void-cust_bill.cgi
+++ b/httemplate/misc/void-cust_bill.cgi
@@ -1,0 +1,46 @@
+<& /elements/header-popup.html, mt('Void invoice') &>
+
+<% include('/elements/error.html') %>
+
+<% emt('Are you sure you want to void this invoice?') %>
+<BR><BR>
+
+<% emt("Invoice #[_1] ([_2])",$cust_bill->display_invnum, $money_char. $cust_bill->owed) %>
+<BR><BR>
+
+<FORM METHOD="POST" ACTION="process/void-cust_bill.html">
+<INPUT TYPE="hidden" NAME="invnum" VALUE="<% $invnum %>">
+
+<% ntable("#cccccc", 2) %>
+<& /elements/tr-select-reason.html,
+             'field'          => 'reasonnum',
+             'reason_class'   => 'X',
+             'cgi'            => $cgi
+&>
+
+</TABLE>
+
+<BR>
+<CENTER>
+<BUTTON TYPE="submit">Yes, void invoice</BUTTON>&nbsp;&nbsp;&nbsp;\
+<BUTTON TYPE="button" onClick="parent.cClick();">No, do not void invoice</BUTTON>
+</CENTER>
+
+</FORM>
+</BODY>
+</HTML>
+<%init>
+
+die "access denied"
+  unless $FS::CurrentUser::CurrentUser->access_right('Void invoices');
+
+my $conf = new FS::Conf;
+my $money_char = $conf->config('money_char') || '$';
+
+#untaint invnum
+$cgi->param('invnum') =~ /^(\d+)$/ || die "Illegal invnum";
+my $invnum = $1;
+
+my $cust_bill = qsearchs('cust_bill',{'invnum'=>$invnum});
+
+</%init>

--- a/httemplate/misc/void-cust_credit.cgi
+++ b/httemplate/misc/void-cust_credit.cgi
@@ -12,7 +12,7 @@
 
 <P ALIGN="center"><B><% mt('Void this credit?') |h %></B>
 
-<FORM action="<% ${p} %>misc/void-cust_credit.html">
+<FORM action="<% ${p} %>misc/void-cust_credit.cgi">
 <INPUT TYPE="hidden" NAME="crednum" VALUE="<% $crednum %>">
 
 <TABLE BGCOLOR="#cccccc" BORDER="0" CELLSPACING="2" STYLE="margin-left:auto; margin-right:auto">

--- a/httemplate/misc/void-cust_pay.cgi
+++ b/httemplate/misc/void-cust_pay.cgi
@@ -1,16 +1,52 @@
-%if ( $error ) {
-%  errorpage($error);
+%if ( $success ) {
+<& /elements/header-popup.html, mt("Payment voided") &>
+  <SCRIPT TYPE="text/javascript">
+    window.top.location.reload();
+  </SCRIPT>
+  </BODY>
+</HTML>
 %} else {
-<% $cgi->redirect($p. "view/cust_main.cgi?custnum=". $custnum. ";show=payment_history") %>
+<& /elements/header-popup.html, mt('Void payment')  &>
+
+<& /elements/error.html &>
+
+<P ALIGN="center"><B><% mt('Void this payment?') |h %></B>
+
+<FORM action="<% ${p} %>misc/void-cust_pay.cgi">
+<INPUT TYPE="hidden" NAME="paynum" VALUE="<% $paynum %>">
+
+<TABLE BGCOLOR="#cccccc" BORDER="0" CELLSPACING="2" STYLE="margin-left:auto; margin-right:auto">
+<& /elements/tr-select-reason.html,
+             'field'          => 'reasonnum',
+             'reason_class'   => 'X',
+             'cgi'            => $cgi
+&>
+</TABLE>
+
+<BR>
+<P ALIGN="CENTER">
+<INPUT TYPE="submit" NAME="confirm_void_payment" VALUE="<% mt('Void payment') |h %>"> 
+&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;
+<INPUT TYPE="BUTTON" VALUE="<% mt("Don't void payment") |h %>" onClick="parent.cClick();"> 
+
+</FORM>
+</BODY>
+</HTML>
+
 %}
 <%init>
 
 #untaint paynum
-my($query) = $cgi->keywords;
-$query =~ /^(\d+)$/ || die "Illegal paynum";
-my $paynum = $1;
+my $paynum = $cgi->param('paynum');
+if ($paynum) {
+  $paynum =~ /^(\d+)$/ || die "Illegal paynum";
+} else {
+  my($query) = $cgi->keywords;
+  $query =~ /^(\d+)/ || die "Illegal paynum";
+  $paynum = $1;
+}
 
-my $cust_pay = qsearchs('cust_pay',{'paynum'=>$paynum});
+my $cust_pay = qsearchs('cust_pay',{'paynum'=>$paynum}) || die "Payment not found";
 
 my $right = 'Void payments';
 $right = 'Credit card void' if $cust_pay->payby eq 'CARD';
@@ -19,8 +55,24 @@ $right = 'Echeck void'      if $cust_pay->payby eq 'CHEK';
 die "access denied"
   unless $FS::CurrentUser::CurrentUser->access_right($right);
 
-my $custnum = $cust_pay->custnum;
+my $success = 0;
+if ($cgi->param('confirm_void_payment')) {
 
-my $error = $cust_pay->void;
+  #untaint reasonnum / create new reason
+  my ($reasonnum, $error) = $m->comp('process/elements/reason');
+  if (!$reasonnum) {
+    $error = 'Reason required';
+  } else {
+    my $reason = qsearchs('reason', { 'reasonnum' => $reasonnum })
+      || die "Reason num $reasonnum not found in database";
+	$error = $cust_pay->void($reason) unless $error;
+  }
+
+  if ($error) {
+    $cgi->param('error',$error);
+  } else {
+    $success = 1;
+  }
+}
 
 </%init>

--- a/httemplate/misc/void-cust_pay.cgi
+++ b/httemplate/misc/void-cust_pay.cgi
@@ -1,7 +1,7 @@
 %if ( $error ) {
 %  errorpage($error);
 %} else {
-<% $cgi->redirect($p. "view/cust_main.cgi?". $custnum) %>
+<% $cgi->redirect($p. "view/cust_main.cgi?custnum=". $custnum. ";show=payment_history") %>
 %}
 <%init>
 

--- a/httemplate/view/cust_bill.cgi
+++ b/httemplate/view/cust_bill.cgi
@@ -9,13 +9,30 @@ function areyousure(href, message) {
 }
 </SCRIPT>
 
-% if ( !$cust_bill->closed && $curuser->access_right('Void invoices') ) {
+% if ( !$cust_bill->closed ) { # otherwise allow no changes
+%   my $can_delete = $conf->exists('deleteinvoices')
+%                    && $curuser->access_right('Delete invoices');
+%   my $can_void = $curuser->access_right('Void invoices');
+%   if ( $can_void ) {
     <& /elements/popup_link.html,
       'label'       => emt('Void this invoice'),
       'actionlabel' => emt('Void this invoice'),
-      'action'      => $p.'misc/void-cust_bill.html?invnum='.$invnum,
+      'action'      => $p.'misc/void-cust_bill.cgi?invnum='.$invnum,
     &>
-    <BR><BR>
+%   }
+%   if ( $can_void and $can_delete ) {
+  &nbsp;|&nbsp;
+%   }
+%   if ( $can_delete ) {
+    <A href="" onclick="areyousure(\
+      '<%$p%>misc/delete-cust_bill.html?<% $invnum %>',\
+      <% mt('Are you sure you want to delete this invoice?') |js_string %>)"\
+    TITLE = "<% mt('Delete this invoice from the database completely') |h %>">\
+    <% emt('Delete this invoice') |h %></A>
+%   }
+%   if ( $can_void or $can_delete ) {
+  <BR><BR>
+%   }
 % }
 
 % if ( $cust_bill->owed > 0

--- a/httemplate/view/cust_main/payment_history/credit.html
+++ b/httemplate/view/cust_main/payment_history/credit.html
@@ -130,7 +130,7 @@ my $void = '';
 $void = ' ('.
                include( '/elements/popup_link.html',
                     'label'    => emt('void'),
-                    'action'   => "${p}misc/void-cust_credit.html?".
+                    'action'   => "${p}misc/void-cust_credit.cgi?".
                                   $cust_credit->crednum,
                     'actionlabel' => emt('Void credit'),
                 ).

--- a/httemplate/view/cust_main/payment_history/invoice.html
+++ b/httemplate/view/cust_main/payment_history/invoice.html
@@ -27,7 +27,7 @@ if ( $cust_bill->closed !~ /^Y/i && $opt{'Void invoices'} ) {
   $void =
     ' ('. include('/elements/popup_link.html',
                     'label'     => emt('void'),
-                    'action'    => "${p}misc/void-cust_bill.html?;invnum=".
+                    'action'    => "${p}misc/void-cust_bill.cgi?;invnum=".
                                     $cust_bill->invnum,
                     'actionlabel' => emt('Void Invoice'),
                  ).

--- a/httemplate/view/cust_main/payment_history/payment.html
+++ b/httemplate/view/cust_main/payment_history/payment.html
@@ -1,5 +1,5 @@
 <% $payment. ' '.  $info. $desc.
-   $view. $change_pkg. $apply. $refund. $void. $unapply
+   $view. $change_pkg. $apply. $refund. $void. $delete. $unapply
 %>
 <%init>
 
@@ -154,36 +154,47 @@ if ( $apply && $opt{'pkg-balances'} && $cust_pay->pkgnum ) {
 
 my $refund = '';
 my $refund_days = $opt{'card_refund-days'} || 120;
-my @refund_right = grep { $opt{$_} } $FS::CurrentUser::CurrentUser->refund_rights($cust_pay->payby);
+my $refund_right = '';
+$refund_right = 'Refund credit card payment' if $cust_pay->payby eq 'CARD';
+$refund_right = 'Refund Echeck payment'      if $cust_pay->payby eq 'CHEK';
 if (    $cust_pay->closed !~ /^Y/i
-     && $cust_pay->payby =~ /^(CARD|CHEK|BILL)$/
+     && $cust_pay->payby =~ /^(CARD|CHEK)$/
      && time-$cust_pay->_date < $refund_days*86400
      && $cust_pay->unrefunded > 0
-     && scalar(@refund_right)
+     && $opt{$refund_right}
 ) {
-  my $refundtitle = ($cust_pay->payby =~ /^(CARD|CHEK)$/)
-            ? emt('Send a refund for this payment to the payment gateway')
-            : emt('Record a refund for this payment');
   $refund = qq! (<A HREF="${p}edit/cust_refund.cgi?payby=$1;!.
             qq!paynum=!. $cust_pay->paynum. '"'.
-            qq! TITLE="! . $refundtitle
+            qq! TITLE="! .emt('Send a refund for this payment to the payment gateway') 
             . '">' . emt('refund') . '</A>)';
 }
 
 my $void = '';
-my $voidmsg = $cust_pay->payby =~ /^(CARD|CHEK)$/
+my $voidmsg = $cust_pay->payby =~ /^(CARD|CHEK|TOKN)$/
               ? ' (' . emt('do not send anything to the payment gateway').')'
               : '';
-$void = areyousure_link("${p}misc/void-cust_pay.cgi?".$cust_pay->paynum,
-                        emt('Are you sure you want to void this payment?'),
-                        emt('Void this payment from the database') . $voidmsg,
-                        emt('void')
-                       )
+$void = ' ('.
+               include( '/elements/popup_link.html',
+                    'label'    => emt('void'),
+                    'action'   => "${p}misc/void-cust_pay.cgi?".$cust_pay->paynum,
+                    'actionlabel' => emt('Void payment'),
+                ).
+          ')'
   if $cust_pay->closed !~ /^Y/i
   && (    ( $cust_pay->payby eq 'CARD'          && $opt{'Credit card void'} )
        || ( $cust_pay->payby eq 'CHEK'          && $opt{'Echeck void'}      )
        || ( $cust_pay->payby !~ /^(CARD|CHEK)$/ && $opt{'Void payments'}    )
      );
+
+my $delete = '';
+$delete = areyousure_link("${p}misc/delete-cust_pay.cgi?".$cust_pay->paynum,
+                            emt('Are you sure you want to delete this payment?'),
+                            emt('Delete this payment from the database completely - not recommended'),
+                            emt('delete')
+                         )
+  if $cust_pay->closed !~ /^Y/i
+  && $opt{'deletepayments'}
+  && $opt{'Delete payment'};
 
 my $unapply = '';
 $unapply = areyousure_link("${p}misc/unapply-cust_pay.cgi?".$cust_pay->paynum,

--- a/httemplate/view/cust_main/payment_history/voided_invoice.html
+++ b/httemplate/view/cust_main/payment_history/voided_invoice.html
@@ -6,7 +6,7 @@
 % }
 % my $reason = $cust_bill_void->reason;
 % if ($reason) {
-     (<% $reason %>)
+     (<% $reason |h %>)
 % }
 <% mt("on [_1]", time2str($date_format, $cust_bill_void->void_date) ) |h %> 
 </I>

--- a/httemplate/view/cust_main/payment_history/voided_payment.html
+++ b/httemplate/view/cust_main/payment_history/voided_payment.html
@@ -6,7 +6,7 @@
 % }
 % my $reason = $cust_pay_void->reason;
 % if ($reason) {
-     (<% $reason %>)
+     (<% $reason |h %>)
 % }
 <% mt("on [_1]", time2str($date_format, $cust_pay_void->void_date) ) |h %> 
 </I>


### PR DESCRIPTION
This converts the reasons used for invoice and payment void methods from text string to a classified FS::reason
The changes are more related to the FS object's method interfaces than the freeside UI. The current UI used to void payments and invoices is untouched but there are changes in the navigation (page redirects) to stay on the payment_history page when payment apply / unapply / void / unvoid was invoked. Also a new section in the menu was added to manage the void reasons in Configuration --> Billing.