### PR TITLE
Bug fix: "User not found." error when logging into selfservicecgi wit…

### DIFF
--- a/FS/FS/contact.pm
+++ b/FS/FS/contact.pm
@@ -773,7 +773,7 @@ sub by_selfservice_email {
     'addl_from' => ' LEFT JOIN contact USING ( contactnum ) ',
     'hashref'   => { 'emailaddress' => $email, },
     'extra_sql' => " AND ( contact.disabled IS NULL ) ".
-                   " AND ( contact.selfservice_access = 'Y' )",
+                   " AND ( cust_contact.selfservice_access = 'Y' )",
   }) or return '';
 
   $contact_email->contact;


### PR DESCRIPTION
…h contact email address

Name: "User not found." error in selfservice.cgi
Description: Entering a "Self-Service access without service" email address in selfservice.cgi results in "User not found".
Expected: Successful login.
Reproduce: Login to selfservice with any valid contact email address.
Affects: Selfservice login in Freeside 4.1, 4.2~git-1
Cause: This worked in 4.0, a change was made in 4.1:
Workaround:     Modify /usr/share/perl5/FS/contact.pm
                Change the trailing . to a , in:
                'extra_sql' => " AND ( contact.disabled IS NULL ) ",
                Comment this line:
                #" AND ( contact.selfservice_access = 'Y' )
Recommended fix:
In:
/usr/share/perl5/FS/contact.pm
Change:
" AND ( contact.selfservice_access = 'Y' )",
To:
" AND ( cust_contact.selfservice_access = 'Y' )",

Notes: contact.selfservice_access is deprecated according to /usr/share/perl5/FS/Schema.pm