### PR TITLE
Bug fix Erreu/Freeside#5 "Change xyz" in selfservice resets cust_contact.selfservice_access to NULL

### DIFF
--- a/FS/FS/ClientAPI/MyAccount.pm
+++ b/FS/FS/ClientAPI/MyAccount.pm
@@ -784,7 +784,9 @@ sub edit_info {
     @invoicing_list = split( /\s*\,\s*/, $p->{'invoicing_list'} );
     push @invoicing_list, 'POST' if $p->{'postal_invoicing'};
   } else {
-    @invoicing_list = $cust_main->invoicing_list;
+    my $error = $new->replace($cust_main);
+    return { 'error' => $error } if $error;
+    return { 'error' => '' };
   }
 
   my $error = $new->replace($cust_main, \@invoicing_list);


### PR DESCRIPTION
Bug fix Erreu/Freeside#5 "Change xyz" in selfservice resets cust_contact.selfservice_access to NULL
Description: Making unrelated account changes in selfservice resets cust_contact.selfservice_access and cust_contact.classnum to NULL when contact.last and contact.first match cust_main.last and cust_main.first

Expected: cust_contact.selfservice_access and cust_contact.classnum should only change when their values are modified by the user

Reproduce: Login to selfservice, choose one of change billing address, service address, payment information, choose "Apply changes".

Affects: Freeside 4.1 & 4.2~git-1

Cause: Bug Erreu/Freeside/issues/2 in cust_main::replace is being exposed by Account::edit_info passing $cust_main->invoicing_list back to cust_main::replace (unnecessarily)

Workaround: Ensure that contact.last and contact.first do not match cust_main.last and cust_main.first (even a single character difference is sufficient, for example a comma after the last name)

Notes:

    MyAccount::edit_info populates @invoicing_list with the preexisting values if the enduser hasn't made any changes to it. Since INVOICING_LIST_ARYREF is both optional and deprecated, this appears to be unnecessary overhead.

Recommended fix: If the user has not modified $invoicing_list, do not pass it to cust_main::replace

Pull request: freeside/Freeside#59