### PR TITLE
Bug fix Erreu/Freeside#1 "User not found." error in selfservice.cgi

### DIFF
--- a/FS/FS/contact.pm
+++ b/FS/FS/contact.pm
@@ -760,8 +760,8 @@ sub contact_email {
 =item by_selfservice_email EMAILADDRESS
 
 Alternate search constructor (class method).  Given an email address, returns
-the contact for that address. If that contact doesn't have selfservice access,
-or there isn't one, returns the empty string.
+the contact for that address, or the empty string if no contact has that
+email address.
 
 =cut
 
@@ -772,8 +772,7 @@ sub by_selfservice_email {
     'table'     => 'contact_email',
     'addl_from' => ' LEFT JOIN contact USING ( contactnum ) ',
     'hashref'   => { 'emailaddress' => $email, },
-    'extra_sql' => " AND ( contact.disabled IS NULL ) ".
-                   " AND ( contact.selfservice_access = 'Y' )",
+    'extra_sql' => " AND ( contact.disabled IS NULL ) ",
   }) or return '';
 
   $contact_email->contact;


### PR DESCRIPTION
Name: "User not found." error in selfservice.cgi
Description: Entering a "Self-Service access without service" email address in selfservice.cgi results in "User not found".
Expected: Successful login.
Reproduce: Login to selfservice with any valid contact email address.
Affects: Selfservice login in Freeside 4.1, 4.2~git-1
Cause: This worked in 4.0, a change was made in 4.1:
Workaround: Modify /usr/share/perl5/FS/contact.pm
Change the trailing . to a , in:
'extra_sql' => " AND ( contact.disabled IS NULL ) ",
Comment this line:
#" AND ( contact.selfservice_access = 'Y' )
Recommended fix:
Remove the non-functional test entirely. MyAccount::login already has a test for cust_contact.selfservice_access that seems fully functional making the non-functional newly added test redundant.

Notes: contact.selfservice_access is deprecated according to /usr/share/perl5/FS/Schema.pm