### PR TITLE
Deploy_zone perl error fixed

### DIFF
--- a/FS/FS/deploy_zone.pm
+++ b/FS/FS/deploy_zone.pm
@@ -418,6 +418,8 @@ sub process_block_lookup {
     die $response->status_line unless $response->is_success;
     $data = decode_json($response->content);
     die $data->{error}{message} if $data->{error};
+    #Nothing to insert 
+    last unless (scalar @{$data->{features}} > 0);
 
     foreach my $feature (@{ $data->{features} }) {
       my $geoid = $feature->{attributes}{GEOID}; # the prize


### PR DESCRIPTION
Deploy_zone Perl error while fetching non existing value fixed.

> Error: Modification of non-creatable array value attempted, subscript -1 at /usr/share/perl5/FS/deploy_zone.pm line 439.

Error will encountered whenever there will be no data available for selected deployment zone.
More info:- 

The data request from URL can be empty when no census data is available for any done.
In such case code is still trying to insert and iterate on  non existing values. Also the line 

    $last_oid = $data->{features}[-1]{attributes}{OID};

is trying to access non existing value. Hence fix will prevent this error and let the code proceed further.
As per the functionality we do add deployment zone when no data is prevent and fix will allow the same.

Enable the following setting 
part_pkg-show_fcc_options  by navigating to configurations > settings

then navigate to 
Reports > Packages > FCC Form 477
and try adding zone (for test try such place where the data  will be unavailable )

![error](https://user-images.githubusercontent.com/31588634/38444439-c395a3dc-3a0c-11e8-8e88-cc8c06c2b142.JPG)

Let me know if you have any concern or need some more input about fix.
I was not sure where to and how to raise RT ticket for this hence fixed directly.
