### PR TITLE
Added support for collecting censustract data from U.S. Census Bureau.

### DIFF
--- a/FS/FS/Conf.pm
+++ b/FS/FS/Conf.pm
@@ -4876,9 +4876,31 @@ and customer address. Include units.',
   {
     'key'         => 'census_year',
     'section'     => 'UI',
-    'description' => 'The year to use in census tract lookups.  NOTE: you need to select 2012 or 2013 for Year 2010 Census tract codes.  A selection of 2011 provides Year 2000 Census tract codes.  Use the freeside-censustract-update tool if exisitng customers need to be changed.',
+    'description' => 'The year to use in census tract lookups.<br>NOTE: which year you choose varies depending on which censustract source you are using.  When using the default (ffiec) you need to select 2012 for Year 2010 Census tract codes and a selection of 2011 for Year 2000 Census tract codes.  When using FCC or U.S. Census Bureau you must choose 2020 or 2010.  Use the freeside-censustract-update tool if exisiting customers need to be changed.',
     'type'        => 'select',
-    'select_enum' => [ qw( 2017 2016 2015 ) ],
+    'select_enum' => [ qw( 2020 2012 2010 ) ],
+  },
+
+  {
+    'key'         => 'censustract_source_method',
+    'section'     => 'UI',
+    'description' => 'Select which institution you want as the source for censustract data.  Default: ffiec',
+    'type'        => 'select',
+    'select_hash' => [ '' => '',
+                       'ffiec'    => 'Federal Financial Institutions Examination Council (FFIEC)',
+                       'uscensus' => 'U.S. Census Bureau',
+                     ],
+  },
+
+  {
+    'key'         => 'censustract_block_format',
+    'section'     => 'UI',
+    'description' => 'Choose the format to use when storing the censustract data.  To collect and store the 15 digit format, censustract_source_method must be set to U.S. Census Bureau.  The U.S. Census Bureau is the only source that provides the 4 digit block data.  Default: 11 digits',
+    'type'        => 'select',
+    'select_hash' => [ '' => '',
+                       '11' => '11 digits, Ex: 410170007.02',
+                       '15' => '15 digits, Ex: 410170007021064',
+                     ],
   },
 
   {

--- a/FS/FS/GeocodeCache.pm
+++ b/FS/FS/GeocodeCache.pm
@@ -123,7 +123,9 @@ sub set_censustract {
   my $censusyear = $conf->config('census_year');
   return if !$censusyear;
 
-  my $method = 'ffiec';
+  my $method = $conf->config('censustract_source_method');
+  $method ||= 'ffiec';
+
   # configurable censustract-only lookup goes here if it's ever needed.
   $method = "get_censustract_$method";
   my $censustract = eval { FS::Misc::Geo->$method($self, $censusyear) };

--- a/FS/FS/Misc/Geo.pm
+++ b/FS/FS/Misc/Geo.pm
@@ -104,6 +104,74 @@ sub get_censustract_ffiec {
   }
 }
 
+=item get_censustract_uscensus LOCATION YEAR
+
+Given a location hash (see L<FS::location_Mixin>) and a census map year,
+returns a census tract code (consisting of state, county, tract, and block
+codes) or an error message.
+
+=cut
+
+sub get_censustract_uscensus {
+  my $class = shift;
+  my $location = shift;
+  my $year  = shift;
+  $year ||= 2012;
+
+  if ( length($location->{country}) and uc($location->{country}) ne 'US' ) {
+    return '';
+  }
+
+  warn Dumper($location, $year) if $DEBUG;
+  my $url = 'https://geocoding.geo.census.gov/geocoder/geographies/address?';
+
+  my $query_hash = {
+                 street     => "$location->{address1}",
+                 city       => "$location->{city}",
+                 state      => "$location->{state}",
+                 benchmark  => "Public_AR_Current",
+                 vintage    => "Census".$year."_Current",
+                 format     => "json"
+                 };
+
+  my $full_url = URI->new($url);
+  $full_url->query_form($query_hash);
+
+  warn "Full Request URL: \n".$full_url if $DEBUG;
+
+  my $ua = new LWP::UserAgent;
+  my $res = $ua->get( $full_url );
+
+  warn $res->as_string if $DEBUG > 2;
+
+  if (!$res->is_success) {
+    die "Census tract lookup error: ".$res->message;
+  }
+
+  local $@;
+  my $content = eval { decode_json($res->content) };
+  die "Census tract JSON error: $@\n" if $@;
+
+  warn Dumper($content) if $DEBUG;
+
+  if ( $content->{result}->{addressMatches} ) {
+
+    my $tract = $content->{result}->{addressMatches}[0]->{geographies}->{'Census Blocks'}[0]->{GEOID};
+    return $tract;
+
+  } else {
+
+    my $error = 'Lookup failed, but with no status message.';
+
+    if ( $content->{errors} ) {
+      $error = join("\n", $content->{errors});
+    }
+    
+    die "$error\n";
+
+  }
+}
+
 #sub get_district_methods {
 #  ''         => '',
 #  'wa_sales' => 'Washington sales tax',

--- a/FS/FS/cust_location.pm
+++ b/FS/FS/cust_location.pm
@@ -380,10 +380,19 @@ sub check {
   ;
   return $error if $error;
   if ( $self->censustract ne '' ) {
-    $self->censustract =~ /^\s*(\d{9})\.?(\d{2})\s*$/
+
+    my $censustract_block_format = $conf->config('censustract_block_format');
+    $censustract_block_format ||= '11';
+
+    $self->censustract =~ /^\s*(\d{9})\.?(\d{2})(\d{4})?\s*$/
       or return "Illegal census tract: ". $self->censustract;
 
-    $self->censustract("$1.$2");
+    if ( $censustract_block_format == '15' ) {
+      $self->censustract("$1$2$3");
+    } else {
+      $self->censustract("$1.$2");
+    }
+
   }
 
   #yikes... this is ancient, pre-dates cust_location and will be harder to


### PR DESCRIPTION
Added support for 15 digit censustract + block format now required by
the FCC as of Jan 1 2022 when filing Form 477.