### PR TITLE
Must respect the cust-fields config param

### DIFF
--- a/httemplate/search/cust_event_fee.html
+++ b/httemplate/search/cust_event_fee.html
@@ -99,7 +99,7 @@ $search{'ending'}    = $ending;
 
 my $where = ' WHERE '. FS::cust_event_fee->search_sql_where( \%search );
 
-my $join = FS::cust_event_fee->join_sql();
+my $join = FS::cust_event_fee->join_sql() . FS::UI::Web::join_cust_main('cust_main');
 
 my $sql_query = {
   'table'     => 'cust_event_fee',


### PR DESCRIPTION
If you set `cust-fields` to anything other than the default, it will croak on the `cust_event_fee.html` page. This page will address that by capturing the table in the JOIN clause.