### PR TITLE
Escape single quotes in detail rows

### DIFF
--- a/httemplate/edit/elements/detail-table.html
+++ b/httemplate/edit/elements/detail-table.html
@@ -66,6 +66,7 @@ Expects to be the last element in a two-column table with specified id
   detail_table_info.field['<% $id %>'] = '<% $field %>';
   detail_table_info.rownum['<% $id %>'] = 0;
 % foreach my $detail ( @details ) { 
+% $detail =~ s/'/\\'/g;
   addDetailRow('<% $id %>','<% $detail %>');
 % } 
 </SCRIPT>


### PR DESCRIPTION
Escape single quotes in detail variable for safety.